### PR TITLE
Fix python3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-signalr-client==0.0.5
+signalr-client==0.0.7

--- a/sensors/signalr_hub_sensor.py
+++ b/sensors/signalr_hub_sensor.py
@@ -22,10 +22,12 @@ class SignalRHubSensor(Sensor):
         self.connection = Connection(self.url, self.session)
         # start a connection
         self.connection.start()
+
         # add a handler to process notifications to the connection
-        self.connection.handlers += \
-            lambda data: self._logger.debug(
-                'Connection: new notification - %s' % data)
+        def _log_notifications(data):
+            self._logger.debug('Connection: new notification - {}'.format(data))
+        self.connection.handlers += _log_notifications  # noqa pylint: disable=no-member
+
         # get hub
         self._hub = self.connection.hub(self.hub_name)
 


### PR DESCRIPTION
Bump signalr-client dependency to fix an import issue, and fix Python 3 syntax.